### PR TITLE
Add support for internal and external link routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- Support for internal and external link routes.
+
 ### Changed
 - Hide menu on mobile mode
 

--- a/react/Menu.js
+++ b/react/Menu.js
@@ -50,10 +50,15 @@ class Menu extends Component {
         className = `${VTEXClasses.LINK_RIGHT} ${className}`
         break
     }
+    console.log(link.typeOfRoute)
     return (
-      <Link key={link.title} className={`${className}`} page={link.url}>
-        {link.title}
-      </Link>
+      link.typeOfRoute === 'INTERNAL'
+        ? <a className={className} href={link.url}>
+            {link.title}
+          </a>
+        : <Link key={link.title} className={className} page={link.url}>
+            {link.title}
+          </Link>
     )
   }
 
@@ -121,6 +126,9 @@ MenuWithIntl.getSchema = ({ numberOfItems }) => {
   const intl = MenuWithIntl.intl
   const descriptionIntl = (intl && intl.formatMessage({ id: 'menu.description' })) || 'A menu bar of links'
   const titleIntl = (intl && intl.formatMessage({ id: 'menu.title' })) || 'Title'
+  const typeOfRouteIntl = (intl && intl.formatMessage({ id: 'menu.typeOfRoute' })) || 'Type of Route'
+  const internalIntl = (intl && intl.formatMessage({ id: 'menu.typeOfRoute.internal' })) || 'Internal'
+  const externalIntl = (intl && intl.formatMessage({ id: 'menu.typeOfRoute.external' })) || 'External'
   const numberOfItemsIntl = (intl && intl.formatMessage({ id: 'menu.numberOfItems' })) || 'Number of items'
   const positionIntl = (intl && intl.formatMessage({ id: 'menu.position' })) || 'Position'
   const leftIntl = (intl && intl.formatMessage({ id: 'menu.position.left' })) || 'LEFT'
@@ -131,7 +139,7 @@ MenuWithIntl.getSchema = ({ numberOfItems }) => {
     dynamicProperties[`item${i}`] = {
       type: 'object',
       title: `Item #${i}`,
-      required: ['title', 'url', 'position'],
+      required: ['title', 'url', 'typeOfRoute', 'position'],
       properties: {
         title: {
           title: titleIntl,
@@ -140,6 +148,13 @@ MenuWithIntl.getSchema = ({ numberOfItems }) => {
         url: {
           title: 'URL',
           type: 'string',
+        },
+        typeOfRoute: {
+          title: typeOfRouteIntl,
+          type: 'string',
+          enum: ['INTERNAL', 'EXTERNAL'],
+          enumNames: [internalIntl, externalIntl],
+          default: 'INTERNAL',
         },
         position: {
           title: positionIntl,

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -1,5 +1,8 @@
 {
   "menu.title": "Title",
+  "menu.typeOfRoute": "Type of Route",
+  "menu.typeOfRoute.internal": "Internal",
+  "menu.typeOfRoute.external": "External",
   "menu.description": "A menu bar of links",
   "menu.position": "Position",
   "menu.numberOfItems": "Number of items",

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -1,5 +1,8 @@
 {
   "menu.title": "Título",
+  "menu.typeOfRoute": "Tipo da Rota",
+  "menu.typeOfRoute.internal": "Interna",
+  "menu.typeOfRoute.external": "Externo",
   "menu.description": "Una barra de menú de enlaces",
   "menu.position": "Posición",
   "menu.numberOfItems": "Número de elementos",

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -1,5 +1,8 @@
 {
   "menu.title": "Título",
+  "menu.typeOfRoute": "Tipo da Rota",
+  "menu.typeOfRoute.internal": "Interna",
+  "menu.typeOfRoute.external": "Externa",
   "menu.description": "Uma barra de menu com links",
   "menu.position": "Posição",
   "menu.numberOfItems": "Número de elementos",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add support for internal and external link routes

#### What problem is this solving?
Menu component have used the Link component whenever the link was internal or external.

#### How should this be manually tested?

#### Screenshots or example usage
<a href="https://gustavo--storecomponents.myvtex.com/_v/app/vtex.menu@0.1.1/react/Menu">Workspace</a>

![screenshot from 2018-05-28 01-48-04](https://user-images.githubusercontent.com/9275109/40597669-3aff4cbe-6219-11e8-992f-4d695052b218.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
