### PR TITLE
Remove menu border bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- remove menu border-bottom.
 
 ## [0.3.0] - 2018-6-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - remove border-bottom of `menu`.
+- height of `menu` to 1.5625rem.
 
 ## [0.3.0] - 2018-6-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 - remove border-bottom from `menu`.
-- height of `menu` to 1.5625rem.
+- decreased menu height.
 
 ## [0.3.0] - 2018-6-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- remove border-bottom of `menu`.
+- remove border-bottom from `menu`.
 - height of `menu` to 1.5625rem.
 
 ## [0.3.0] - 2018-6-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- remove border-bottom of menu.
+- remove border-bottom of `menu`.
 
 ## [0.3.0] - 2018-6-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Changed
-- remove menu border-bottom.
+- remove border-bottom of menu.
 
 ## [0.3.0] - 2018-6-11
 

--- a/react/Menu.js
+++ b/react/Menu.js
@@ -197,7 +197,7 @@ export default class Menu extends Component {
     const links = this.getLinksFromProps()
     return (
       <div className={`${VTEXClasses.MAIN_CLASS} w-100 dn db-ns`}>
-        <nav className="flex justify-between bb b--white-10 bg-near-black">
+        <nav className="flex justify-between bg-near-black">
           <div className="flex-grow pa3 flex items-center">
             {links.filter(link => link['position'] === Options.LEFT).map(link => {
               return this.renderLink(link)

--- a/react/__test__/__snapshots__/Menu.test.js.snap
+++ b/react/__test__/__snapshots__/Menu.test.js.snap
@@ -6,7 +6,7 @@ exports[`Menu Component should match snapshot 1`] = `
     class="vtex-menu w-100 dn db-ns"
   >
     <nav
-      class="flex justify-between bb b--white-10 bg-near-black"
+      class="flex justify-between bg-near-black"
     >
       <div
         class="flex-grow pa3 flex items-center"

--- a/react/global.css
+++ b/react/global.css
@@ -1,3 +1,3 @@
 .vtex-menu nav {
-  height: 37px;
+  height: 1.5625rem;
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Remove border-bottom of menu.

#### How should this be manually tested?
https://claudivan--storecomponents.myvtex.com/make-b--brilho-labial-star-lip-7ml-166starlipbril/p

#### Screenshots or example usage
### Desk:top:
![screenshot from 2018-08-14 15-27-34](https://user-images.githubusercontent.com/4960686/44110726-db599fc0-9fd6-11e8-8678-36a15af0b3de.png)
### Tablet
![screenshot from 2018-08-14 15-29-10](https://user-images.githubusercontent.com/4960686/44110729-e02f0242-9fd6-11e8-9d23-1fcc99ff6472.png)
### Mobile
![screenshot from 2018-08-14 15-28-23](https://user-images.githubusercontent.com/4960686/44110736-e5aac72e-9fd6-11e8-9ec5-2fe281c8ba50.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
