### PR TITLE
Render nothing if there is no links to be displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.1.0] - 2018-12-18
 ### Feature
 - Render nothing if there is no links to be displayed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Feature
+- Render nothing if there is no links to be displayed.
 
 ## [2.0.1] - 2018-11-30
 - Update link rendering to include internal/external.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "menu",
   "vendor": "vtex",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "title": "VTEX Menu",
   "description": "A Menu Component",
   "mustUpdateAt": "2019-04-03",

--- a/react/Menu.tsx
+++ b/react/Menu.tsx
@@ -9,7 +9,7 @@ const GLOBAL_PAGES = (global as any).__RUNTIME__ && Object.keys((global as any).
 
 const MAX_ITEMS: number = 10
 
-type Link = {
+interface Link {
   text?: string
   internalPage?: string
   params?: string
@@ -20,7 +20,7 @@ type Link = {
 }
 
 interface DefaultProps {
-  links: Array<Link>
+  links: Link[]
 }
 
 interface Props extends DefaultProps { }
@@ -55,7 +55,7 @@ class Menu extends Component<Props> {
     links: [],
   }
 
-  static schema: any = {
+  public static schema: any = {
     title: 'editor.menu',
     description: 'editor.menu.description',
     type: 'object',
@@ -128,9 +128,9 @@ class Menu extends Component<Props> {
   private getParams = (params?: string): { [key: string]: string } => {
     const json: { [key: string]: string } = {}
     if (params) {
-      const array: Array<string> = params.split(',')
+      const array: string[] = params.split(',')
       array.forEach((item: string) => {
-        const pair: Array<string> = item.split('=')
+        const pair: string[] = item.split('=')
         json[pair[0]] = pair[1]
       })
     }
@@ -181,26 +181,29 @@ class Menu extends Component<Props> {
 
   public render(): ReactNode {
     const { links } = this.props
+    if (!links.length) {
+      return null
+    }
     return (
       <div className={`${VTEXClasses.MAIN_CLASS} h2 c-muted-2 w-100 dn db-ns`}>
         <nav className="flex justify-between">
           <div className="flex-grow pa3 flex items-center">
             {links
-              .filter(link => link['position'] === Options.LEFT)
+              .filter(link => link.position === Options.LEFT)
               .map((link, index) => {
                 return this.renderLink(link, index)
               })}
           </div>
           <div className="flex-grow pa3 flex items-center">
             {links
-              .filter(link => link['position'] === Options.MIDDLE)
+              .filter(link => link.position === Options.MIDDLE)
               .map((link, index) => {
                 return this.renderLink(link, index)
               })}
           </div>
           <div className="flex-grow pa3 flex items-center">
             {links
-              .filter(link => link['position'] === Options.RIGHT)
+              .filter(link => link.position === Options.RIGHT)
               .map((link, index) => {
                 return this.renderLink(link, index)
               })}


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
The component should be not rendered if there is no links to be displayed.

#### Screenshots or example usage
To test this new feature you need to access the storefront and try to add and remove links from the menu in order to see that the component will not be rendered when there is no links.

[Click here to accces the storefront](https://menu--storecomponents.myvtex.com/admin/cms/storefront)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
