### PR TITLE
add token bg-base on container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Token `bg-base` on container
+
+### Added
+
 - Snapshot tests with react-testing-library.
 
 ## [2.6.5] - 2019-02-14

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -197,7 +197,7 @@ class Menu extends Component<Props> {
       return null
     }
     return (
-      <div className={`${menu.container} h2 c-muted-2 w-100 dn db-ns`}>
+      <div className={`${menu.container} bg-base h2 c-muted-2 w-100 dn db-ns`}>
         <Container>
           <nav className="flex justify-between">
             <div className="flex-grow pa3 flex items-center">


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add bg token on container in order to follow Gocommerce themes

#### What problem is this solving?
Without this class it was necessary set the backgound using css override. This is a problem for themes, in view of that users will may change the tokens colors

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
