### PR TITLE
Add missing translation strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing translations for Portuguese and Spanish.
+
 ## [2.8.0] - 2019-04-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.8.1] - 2019-04-10
+
 ### Fixed
 
 - Add missing translations for Portuguese and Spanish.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "menu",
   "vendor": "vtex",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "title": "VTEX Menu",
   "description": "A Menu Component",
   "mustUpdateAt": "2019-04-03",

--- a/messages/context.json
+++ b/messages/context.json
@@ -35,7 +35,6 @@
   "editor.menu.item.custom.title": "'custom' item type title",
   "editor.menu.item.iconId.title": "iconId title",
   "editor.menu.item.highlight.title": "highlight title",
-  "editor.menu.item.hasSubMenu.title": "hasSubMenu title",
   "editor.menu.item.submenuWidth.title": "subMenuWidth title",
   "editor.menu.item.params.title": "params Title",
   "editor.menu.item.params.categoryId.title": "Category id title",

--- a/messages/en.json
+++ b/messages/en.json
@@ -34,8 +34,7 @@
   "editor.menu.item.category.title": "Category",
   "editor.menu.item.custom.title": "Custom",
   "editor.menu.item.iconId.title": "Icon ID",
-  "editor.menu.item.highlight.title": "Hightlight",
-  "editor.menu.item.hasSubMenu.title": "Has submenu",
+  "editor.menu.item.highlight.title": "Highlight",
   "editor.menu.item.submenuWidth.title": "Submenu Width",
   "editor.menu.item.params.title": "Params",
   "editor.menu.item.params.categoryId.title": "Category ID",
@@ -44,7 +43,7 @@
   "editor.menu.item.params.internal.title": "Internal",
   "editor.menu.item.params.external.title": "External",
   "editor.menu.item.params.href.title": "href",
-  "editor.menu.item.params.noFollow.title": "No follow",
-  "editor.menu.item.params.tagTitle.title": "Tag title",
+  "editor.menu.item.params.noFollow.title": "nofollow attribute",
+  "editor.menu.item.params.tagTitle.title": "title attribute",
   "editor.menu.submenu.title": "Submenu"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -17,5 +17,33 @@
   "editor.menu-link.links.link.position": "Posición",
   "editor.menu-link.links.link.position.left": "Izquierda",
   "editor.menu-link.links.link.position.middle": "Medio",
-  "editor.menu-link.links.link.position.right": "Derecha"
+  "editor.menu-link.links.link.position.right": "Derecha",
+
+  "editor.future-menu.title": "Menú",
+  "editor.future-menu.description": "Menú de navegación",
+  "editor.menu.typography.title": "Tipografía",
+  "editor.menu.typography.description": "Permite elegir la clase de tipografía para ser utilizada por los elementos del menú",
+
+  "editor.menu.orientation.title": "Dirección",
+  "editor.menu.orientation.vertical.label": "vertical",
+  "editor.menu.orientation.horizontal.label": "horizontal",
+
+  "editor.menu.items.title": "Elemento del menú",
+  "editor.menu.item.id.title": "ID",
+  "editor.menu.item.type.title": "Tipo",
+  "editor.menu.item.category.title": "Categoría",
+  "editor.menu.item.custom.title": "Personalizado",
+  "editor.menu.item.iconId.title": "ID de icono",
+  "editor.menu.item.highlight.title": "Destacado",
+  "editor.menu.item.submenuWidth.title": "Ancho del submenú",
+  "editor.menu.item.params.title": "Parámetros",
+  "editor.menu.item.params.categoryId.title": "ID de la categoría",
+  "editor.menu.item.params.text.title": "Texto",
+  "editor.menu.item.params.type.title": "Tipo de enlace",
+  "editor.menu.item.params.internal.title": "Interno",
+  "editor.menu.item.params.external.title": "Externo",
+  "editor.menu.item.params.href.title": "href",
+  "editor.menu.item.params.noFollow.title": "Atributo nofollow",
+  "editor.menu.item.params.tagTitle.title": "Atributo title",
+  "editor.menu.submenu.title": "Submenú"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -17,5 +17,33 @@
   "editor.menu-link.links.link.position": "Posição",
   "editor.menu-link.links.link.position.left": "Esquerda",
   "editor.menu-link.links.link.position.middle": "Centro",
-  "editor.menu-link.links.link.position.right": "Direita"
+  "editor.menu-link.links.link.position.right": "Direita",
+
+  "editor.future-menu.title": "Menu",
+  "editor.future-menu.description": "Menu de navegação",
+  "editor.menu.typography.title": "Tipografia",
+  "editor.menu.typography.description": "Permite escolher a classe de tipografia para ser usada pelos itens do menu",
+
+  "editor.menu.orientation.title": "Orientação",
+  "editor.menu.orientation.vertical.label": "vertical",
+  "editor.menu.orientation.horizontal.label": "horizontal",
+
+  "editor.menu.items.title": "Item do Menu",
+  "editor.menu.item.id.title": "ID",
+  "editor.menu.item.type.title": "Tipo",
+  "editor.menu.item.category.title": "Categoria",
+  "editor.menu.item.custom.title": "Customizado",
+  "editor.menu.item.iconId.title": "ID do ícone",
+  "editor.menu.item.highlight.title": "Destaque",
+  "editor.menu.item.submenuWidth.title": "Largura do Submenu",
+  "editor.menu.item.params.title": "Parâmetros",
+  "editor.menu.item.params.categoryId.title": "ID da Categoria",
+  "editor.menu.item.params.text.title": "Texto",
+  "editor.menu.item.params.type.title": "Tipo de link",
+  "editor.menu.item.params.internal.title": "Interno",
+  "editor.menu.item.params.external.title": "Externo",
+  "editor.menu.item.params.href.title": "href",
+  "editor.menu.item.params.noFollow.title": "Atributo nofollow",
+  "editor.menu.item.params.tagTitle.title": "Atributo title",
+  "editor.menu.submenu.title": "Submenu"
 }

--- a/react/components/Item.tsx
+++ b/react/components/Item.tsx
@@ -17,6 +17,8 @@ const Item : FunctionComponent<ItemProps> = (props) => {
 
   const Comp = menuItemTypes[type] as ItemComponent
 
+  if (!Comp) { return null }
+
   return (
     <Comp {...itemProps} {...rest} />
   )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add missing translation strings.

#### What problem is this solving?
Fix Portuguese and Spanish CMS translations.

#### How should this be manually tested?

Check the CMS here:
https://breno--storecomponents.myvtexdev.com/admin/cms/storefront

#### Screenshots or example usage

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
