### PR TITLE
Allow rich text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow `rich-text` in `submenu`.
 
 ## [2.19.5] - 2019-11-21
 

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,8 @@
     "vtex.store-graphql": "2.x",
     "vtex.flex-layout": "0.x",
     "vtex.native-types": "0.x",
-    "vtex.store-icons": "0.x"
+    "vtex.store-icons": "0.x",
+    "vtex.rich-text": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -33,6 +33,7 @@
       "submenu-col",
       "flex-layout",
       "notification",
+      "rich-text",
       "image"
     ]
   },
@@ -40,7 +41,12 @@
     "component": "SubmenuAccordion",
     "composition": "children",
     "allowed": [
-      "menu"
+      "menu",
+      "info-card",
+      "flex-layout",
+      "notification",
+      "rich-text",
+      "image"
     ]
   },
   "submenu-col": {
@@ -48,7 +54,11 @@
     "composition": "children",
     "allowed": [
       "menu",
-      "info-card"
+      "info-card",
+      "flex-layout",
+      "notification",
+      "rich-text",
+      "image"
     ]
   },
   "unstable--menu": {


### PR DESCRIPTION
### Still missing adding a submenu-row block

#### What is the purpose of this pull request?

Add a rich-text inside the submenu.

#### What problem is this solving?

![image](https://user-images.githubusercontent.com/284515/58059827-f9c5e780-7b44-11e9-93e1-1e3746d6458b.png)

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
