### PR TITLE
Fix/childless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.13.2] - 2019-05-23
 ### Fixed
 - Fixes bug where CategoryMenu would break if `children` was null.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixes bug where CategoryMenu would break if `children` was null.
 
 ## [2.13.1] - 2019-05-08
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "menu",
   "vendor": "vtex",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "title": "VTEX Menu",
   "description": "A Menu Component",
   "mustUpdateAt": "2019-04-03",

--- a/manifest.json
+++ b/manifest.json
@@ -17,5 +17,6 @@
   "dependencies": {
     "vtex.store-components": "3.x",
     "vtex.store-graphql": "2.x"
-  }
+  },
+  "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/components/CategoryMenu.tsx
+++ b/react/components/CategoryMenu.tsx
@@ -35,7 +35,7 @@ const CategoryMenu: FunctionComponent<CategoryMenuProps> = ({
         return (
           <>
             <CategoryLink {...category} isTitle/>
-            {children.map((child: Category) => (
+            {children && children.map((child: Category) => (
               <li key={child.id}>
                 <CategoryLink {...child} />
               </li>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Prevents CategoryMenu from breaking when children is null.

Test @ https://lbebber2--storecomponents.myvtex.com/, on the footer.
Before:
<img width="768" alt="Screen Shot 2019-05-23 at 11 59 58" src="https://user-images.githubusercontent.com/5691711/58263704-e4bea380-7d52-11e9-880e-e19057f9c29c.png">

After:
<img width="628" alt="Screen Shot 2019-05-23 at 12 02 54" src="https://user-images.githubusercontent.com/5691711/58263725-ed16de80-7d52-11e9-8e0e-4b8f88e27678.png">



#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
