### PR TITLE
Fix incorrect prop passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.14.1] - 2019-05-26
+
 ### Fixed
 
 - Prop types warning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Prop types warning.
+
 ## [2.14.0] - 2019-05-25
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "menu",
   "vendor": "vtex",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "title": "VTEX Menu",
   "description": "A Menu Component",
   "mustUpdateAt": "2019-04-03",

--- a/react/components/StyledLink.tsx
+++ b/react/components/StyledLink.tsx
@@ -26,6 +26,7 @@ const StyledLink: FunctionComponent<StyledLinkProps> = props => {
     disabled,
     to,
     children,
+    iconId,
     ...rest
   } = props
 
@@ -80,6 +81,7 @@ export interface StyledLinkProps extends LinkProps {
   typography?: string
   disabled?: boolean
   accordion?: boolean
+  iconId?: string
 }
 
 interface LinkProps {

--- a/react/components/StyledLink.tsx
+++ b/react/components/StyledLink.tsx
@@ -27,6 +27,7 @@ const StyledLink: FunctionComponent<StyledLinkProps> = props => {
     to,
     children,
     iconId,
+    treePath,
     ...rest
   } = props
 
@@ -82,6 +83,7 @@ export interface StyledLinkProps extends LinkProps {
   disabled?: boolean
   accordion?: boolean
   iconId?: string
+  treePath?: string
 }
 
 interface LinkProps {


### PR DESCRIPTION
Removes warnings

```
React does not recognize the `iconId` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `iconid` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

```
React does not recognize the `treePath` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `treepath` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

This second one I thought was happening because of render-runtime, but it is (correctly) not passing down `treePath`. It's the `useTreePath` in `useSubmenuImplementation` that's the problem. I don't have enough context, but this probably shouldn't use the treepath context like this. 🤷‍♀ 