### PR TITLE
Fix menu messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Menu messages.
 
 ## [2.14.1] - 2019-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.14.2] - 2019-05-28
 ### Fixed
 - Menu messages.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "menu",
   "vendor": "vtex",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "title": "VTEX Menu",
   "description": "A Menu Component",
   "mustUpdateAt": "2019-04-03",

--- a/react/Menu.tsx
+++ b/react/Menu.tsx
@@ -139,7 +139,7 @@ Menu.getSchema = ({ additionalDef, title }: MenuSchema) => {
         title: messages.defTitle.id,
         enum: ['none', 'title', 'category'],
         type: 'string',
-        enumNames: [messages.noneDef, messages.titleDef, messages.categoryDef],
+        enumNames: [messages.noneDef.id, messages.titleDef.id, messages.categoryDef.id],
         widget: {
           'ui:widget': 'radio',
         }
@@ -147,7 +147,7 @@ Menu.getSchema = ({ additionalDef, title }: MenuSchema) => {
       ...(additionalDef === 'category' && {
         categoryId: {
           type: 'integer',
-          title: messages.categoryIdTitle,
+          title: messages.categoryIdTitle.id,
         }
       }),
       ...(additionalDef === 'title' && {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Send only the message `id` to the menu component schema.

#### What problem is this solving?
Menu content editor on admin exploding when opened.

#### How should this be manually tested?
Edit menu content on admin.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
