### PR TITLE
Insert blockClass import on files of Menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+
 ### Added
 - Blockclass prop.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.16.0] - 2019-06-12
 ### Added
 - Blockclass prop.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.16.0] - 2019-06-12
+### Added
+- Blockclass prop.
+
 ## [2.15.0] - 2019-06-03
 ### Added
 - Support for vertical orientation and different paddings on Submenu.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.16.0] - 2019-06-14
+
 ### Added
 - Blockclass prop.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-
 ### Added
 - Blockclass prop.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "menu",
   "vendor": "vtex",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "title": "VTEX Menu",
   "description": "A Menu Component",
   "mustUpdateAt": "2019-04-03",

--- a/react/Menu.css
+++ b/react/Menu.css
@@ -1,1 +1,2 @@
 .menuContainer {}
+.CustomMenu {}

--- a/react/Menu.css
+++ b/react/Menu.css
@@ -1,2 +1,1 @@
 .menuContainer {}
-.CustomMenu {}

--- a/react/Menu.tsx
+++ b/react/Menu.tsx
@@ -133,12 +133,6 @@ Menu.getSchema = ({ additionalDef, title }: MenuSchema) => {
     title: messages.menuTitle.id,
     type: 'object',
     properties: {
-      blockClass: {
-        title: 'admin/editor.blockClass.title',
-        description: 'admin/editor.blockClass.description',
-        type: 'string',
-        isLayout: true,
-      },
       textType: {
         title: messages.typographyTitle.id,
         type: 'string',

--- a/react/Menu.tsx
+++ b/react/Menu.tsx
@@ -8,6 +8,7 @@ import Item from './components/Item'
 import LevelContext from './components/LevelContext'
 import MenuContext from './components/MenuContext'
 import MenuItem, { MenuItemSchema } from './MenuItem'
+import { generateBlockClass } from '@vtex/css-handles'
 
 import styles from './Menu.css'
 
@@ -27,6 +28,7 @@ const Menu: StorefrontFunctionComponent<MenuSchema> = ({
   textType,
   title,
   categoryId,
+  blockClass,
   ...props
 }) => {
   const level = useContext(LevelContext)
@@ -39,12 +41,14 @@ const Menu: StorefrontFunctionComponent<MenuSchema> = ({
     [orientation, textType]
   ) 
 
+  const classes = generateBlockClass(styles.CustomMenu, blockClass)
+
   return (
     <LevelContext.Provider value={level + 1}>
       <MenuContext.Provider value={menuContext}>
         <nav>
           <ul
-            className={classNames(styles.menuContainer, 'list flex pl0 mv0', {
+            className={classNames(classes, styles.menuContainer, 'list flex pl0 mv0', {
               'flex-column': orientation === 'vertical',
               'flex-row': orientation === 'horizontal',
             })}
@@ -64,7 +68,8 @@ interface MenuSchema {
   categoryId?: number
   textType?: Typography
   title?: MenuItemSchema,
-  additionalDef?: string
+  additionalDef?: string,
+  blockClass?: string
 }
 
 enum Typography {
@@ -128,6 +133,12 @@ Menu.getSchema = ({ additionalDef, title }: MenuSchema) => {
     title: messages.menuTitle.id,
     type: 'object',
     properties: {
+      blockClass: {
+        title: 'admin/editor.blockClass.title',
+        description: 'admin/editor.blockClass.description',
+        type: 'string',
+        isLayout: true,
+      },
       textType: {
         title: messages.typographyTitle.id,
         type: 'string',

--- a/react/Menu.tsx
+++ b/react/Menu.tsx
@@ -41,14 +41,14 @@ const Menu: StorefrontFunctionComponent<MenuSchema> = ({
     [orientation, textType]
   ) 
 
-  const classes = generateBlockClass(styles.CustomMenu, blockClass)
+  const classes = generateBlockClass(styles.menuContainer, blockClass)
 
   return (
     <LevelContext.Provider value={level + 1}>
       <MenuContext.Provider value={menuContext}>
         <nav>
           <ul
-            className={classNames(classes, styles.menuContainer, 'list flex pl0 mv0', {
+            className={classNames(classes, 'list flex pl0 mv0', {
               'flex-column': orientation === 'vertical',
               'flex-row': orientation === 'horizontal',
             })}

--- a/react/MenuItem.css
+++ b/react/MenuItem.css
@@ -1,1 +1,1 @@
-.CustomMenuItem {}
+.menuItem {}

--- a/react/MenuItem.css
+++ b/react/MenuItem.css
@@ -1,0 +1,1 @@
+.CustomMenuItem {}

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -141,12 +141,6 @@ MenuItem.getSchema = props => {
     type: 'object',
     required: ['type'],
     properties: {
-      blockClass: {
-        title: 'admin/editor.blockClass.title',
-        description: 'admin/editor.blockClass.description',
-        type: 'string',
-        isLayout: true,
-      },
       id: {
         default: id,
         title: messages.itemIdTitle.id,

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -9,9 +9,9 @@ import { CategoryItemSchema } from './components/CategoryItem'
 import { CustomItemSchema } from './components/CustomItem'
 import Item from './components/Item'
 import useSubmenuImplementation from './hooks/useSubmenuImplementation'
-import { generateBlockClass } from '@vtex/css-handles' 
+import { generateBlockClass } from '@vtex/css-handles'
 
-import styles from './MenuItem.css' 
+import styles from './MenuItem.css'
 
 const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
   blockClass,

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -24,7 +24,7 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
    * in the future. */
   const submenuImplementation = useSubmenuImplementation()
   const isCollapsible = submenuImplementation === 'submenu.accordion'
-  const classes = generateBlockClass(styles.CustomMenuItem, blockClass)
+  const classes = generateBlockClass(styles.menuItem, blockClass)
 
   if (isCollapsible) {
     return (

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -1,13 +1,22 @@
 import { path } from 'ramda'
 import React, { useState } from 'react'
+
+import classNames from 'classnames'
+
 import { defineMessages } from 'react-intl'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { CategoryItemSchema } from './components/CategoryItem'
 import { CustomItemSchema } from './components/CustomItem'
 import Item from './components/Item'
 import useSubmenuImplementation from './hooks/useSubmenuImplementation'
+import { generateBlockClass } from '@vtex/css-handles' 
 
-const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = props => {
+import styles from './MenuItem.css' 
+
+const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
+  blockClass,
+  ...props
+}) => {
   const [isActive, setActive] = useState(false)
 
   /* This is a temporary check of which kind of submenu is being
@@ -15,10 +24,11 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = props => {
    * in the future. */
   const submenuImplementation = useSubmenuImplementation()
   const isCollapsible = submenuImplementation === 'submenu.accordion'
+  const classes = generateBlockClass(styles.CustomMenuItem, blockClass)
 
   if (isCollapsible) {
     return (
-      <li className="list">
+      <li className={classNames(classes, 'list')}>
         <div
           onClick={event => {
             setActive(!isActive)
@@ -34,7 +44,7 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = props => {
 
   return (
     <li
-      className="list"
+      className={classNames(classes, 'list')}
       onMouseEnter={() => setActive(true)}
       onMouseLeave={() => setActive(false)}>
       <Item {...props} active={isActive} />
@@ -50,6 +60,7 @@ export interface MenuItemSchema {
   iconId: string
   highlight: boolean
   itemProps: CategoryItemSchema | CustomItemSchema
+  blockClass?: string
 }
 
 const messages = defineMessages({
@@ -130,6 +141,12 @@ MenuItem.getSchema = props => {
     type: 'object',
     required: ['type'],
     properties: {
+      blockClass: {
+        title: 'admin/editor.blockClass.title',
+        description: 'admin/editor.blockClass.description',
+        type: 'string',
+        isLayout: true,
+      },
       id: {
         default: id,
         title: messages.itemIdTitle.id,

--- a/react/Submenu.css
+++ b/react/Submenu.css
@@ -1,0 +1,1 @@
+.CustomSubmenu {}

--- a/react/Submenu.css
+++ b/react/Submenu.css
@@ -1,1 +1,1 @@
-.CustomSubmenu {}
+.submenu {}

--- a/react/Submenu.tsx
+++ b/react/Submenu.tsx
@@ -2,9 +2,9 @@ import classNames from 'classnames'
 import React from 'react'
 import { defineMessages } from 'react-intl'
 
-import { generateBlockClass } from '@vtex/css-handles' 
+import { generateBlockClass } from '@vtex/css-handles'
 
-import styles from './Submenu.css' 
+import styles from './Submenu.css'
 
 const MAX_TACHYONS_SCALE = 11
 export type TachyonsScaleInput = string | number | undefined
@@ -55,7 +55,7 @@ const Submenu: StorefrontFunctionComponent<SubmenuProps> = ({
       >
         <section className={classNames(classes, 'w-100 flex justify-center', { 'flex-column': orientation === Orientation.vertical })}>{children}</section>
       </div>
-    </div>  
+    </div>
   )
 }
 

--- a/react/Submenu.tsx
+++ b/react/Submenu.tsx
@@ -39,9 +39,9 @@ const Submenu: StorefrontFunctionComponent<SubmenuProps> = ({
   paddingTop = 4,
   paddingBottom = 4,
 }) => {
-  const classes = generateBlockClass(styles.CustomSubmenu, blockClass)
+  const classes = generateBlockClass(styles.submenu, blockClass)
 
-  return(
+  return (
     <div className={`${width === '100%' ? '' : 'relative'}`}>
       <div
         className={classNames(`absolute left-0 bg-base pt${parseTachyonsValue(paddingTop, 'paddingTop')} pb${parseTachyonsValue(paddingBottom, 'paddingBottom')} bw1 bb b--muted-3 z-2`,

--- a/react/Submenu.tsx
+++ b/react/Submenu.tsx
@@ -93,12 +93,6 @@ Submenu.getSchema = () => ({
   title: messages.submenuTitle.id,
   type: 'object',
   properties: {
-    blockClass: {
-      title: 'admin/editor.blockClass.title',
-      description: 'admin/editor.blockClass.description',
-      type: 'string',
-      isLayout: true,
-    },
     submenuWidth: {
       title: messages.submenuWidthTitle.id,
       enum: ['100%', 'auto'],

--- a/react/Submenu.tsx
+++ b/react/Submenu.tsx
@@ -2,6 +2,10 @@ import classNames from 'classnames'
 import React from 'react'
 import { defineMessages } from 'react-intl'
 
+import { generateBlockClass } from '@vtex/css-handles' 
+
+import styles from './Submenu.css' 
+
 const MAX_TACHYONS_SCALE = 11
 export type TachyonsScaleInput = string | number | undefined
 
@@ -25,29 +29,35 @@ const parseTachyonsValue = (value: TachyonsScaleInput, name?: string) => {
   return parsedValue
 }
 
+
 const Submenu: StorefrontFunctionComponent<SubmenuProps> = ({
   isOpen,
   width,
   children,
+  blockClass,
   orientation = Orientation.horizontal,
   paddingTop = 4,
   paddingBottom = 4,
-}) => (
-  <div className={`${width === '100%' ? '' : 'relative'}`}>
-    <div
-      className={classNames(`absolute left-0 bg-base pt${parseTachyonsValue(paddingTop, 'paddingTop')} pb${parseTachyonsValue(paddingBottom, 'paddingBottom')} bw1 bb b--muted-3 z-2`,
-        {
-          dn: !isOpen,
-          flex: isOpen,
-          'w-100': width === '100%',
-          'w-auto ml6': width === 'auto',
-        }
-      )}
-    >
-      <section className={classNames('w-100 flex justify-center', { 'flex-column': orientation === Orientation.vertical })}>{children}</section>
-    </div>
-  </div>
-)
+}) => {
+  const classes = generateBlockClass(styles.CustomSubmenu, blockClass)
+
+  return(
+    <div className={`${width === '100%' ? '' : 'relative'}`}>
+      <div
+        className={classNames(`absolute left-0 bg-base pt${parseTachyonsValue(paddingTop, 'paddingTop')} pb${parseTachyonsValue(paddingBottom, 'paddingBottom')} bw1 bb b--muted-3 z-2`,
+          {
+            dn: !isOpen,
+            flex: isOpen,
+            'w-100': width === '100%',
+            'w-auto ml6': width === 'auto',
+          }
+        )}
+      >
+        <section className={classNames(classes, 'w-100 flex justify-center', { 'flex-column': orientation === Orientation.vertical })}>{children}</section>
+      </div>
+    </div>  
+  )
+}
 
 enum Orientation {
   horizontal = 'horizontal',
@@ -60,6 +70,7 @@ export interface SubmenuProps extends SubmenuSchema {
   orientation: Orientation
   paddingTop: number | string
   paddingBottom: number | string
+  blockClass?: string
 }
 
 interface SubmenuSchema {
@@ -82,6 +93,12 @@ Submenu.getSchema = () => ({
   title: messages.submenuTitle.id,
   type: 'object',
   properties: {
+    blockClass: {
+      title: 'admin/editor.blockClass.title',
+      description: 'admin/editor.blockClass.description',
+      type: 'string',
+      isLayout: true,
+    },
     submenuWidth: {
       title: messages.submenuWidthTitle.id,
       enum: ['100%', 'auto'],

--- a/react/SubmenuAccordion.css
+++ b/react/SubmenuAccordion.css
@@ -1,0 +1,1 @@
+.CustomSubmenuAccordion {}

--- a/react/SubmenuAccordion.css
+++ b/react/SubmenuAccordion.css
@@ -1,1 +1,1 @@
-.CustomSubmenuAccordion {}
+.submenuAccordion {}

--- a/react/SubmenuAccordion.tsx
+++ b/react/SubmenuAccordion.tsx
@@ -3,9 +3,9 @@ import React from 'react'
 import { defineMessages } from 'react-intl'
 import Collapsible from './components/Collapsible'
 
-import { generateBlockClass } from '@vtex/css-handles' 
+import { generateBlockClass } from '@vtex/css-handles'
 
-import styles from './SubmenuAccordion.css' 
+import styles from './SubmenuAccordion.css'
 
 interface Props {
   isOpen: boolean,

--- a/react/SubmenuAccordion.tsx
+++ b/react/SubmenuAccordion.tsx
@@ -1,27 +1,38 @@
+import classNames from 'classnames'
 import React from 'react'
 import { defineMessages } from 'react-intl'
 import Collapsible from './components/Collapsible'
 
+import { generateBlockClass } from '@vtex/css-handles' 
+
+import styles from './SubmenuAccordion.css' 
+
 interface Props {
-  isOpen: boolean
+  isOpen: boolean,
+  blockClass?: string
 }
 
 const SubmenuAccordion: StorefrontFunctionComponent<Props> = ({
   isOpen,
   children,
-}) => (
-  <Collapsible open={isOpen}>
-    <section
-      className="w-100 flex pl4 flex"
-      style={{
-        WebkitOverflowScrolling: 'touch',
-        maxHeight: 400,
-        overflowY: 'scroll',
-      }}>
-      {children}
-    </section>
-  </Collapsible>
-)
+  blockClass
+}) => {
+  const classes = generateBlockClass(styles.CustomSubmenuAccordion, blockClass)
+
+  return(
+    <Collapsible open={isOpen}>
+      <section
+        className={classNames(classes, "w-100 flex pl4 flex")}
+        style={{
+          WebkitOverflowScrolling: 'touch',
+          maxHeight: 400,
+          overflowY: 'scroll',
+        }}>
+        {children}
+      </section>
+    </Collapsible>
+  )
+}
 
 const messages = defineMessages({
   submenuTitle: {
@@ -33,6 +44,14 @@ const messages = defineMessages({
 SubmenuAccordion.getSchema = () => ({
   title: messages.submenuTitle.id,
   type: 'object',
+  properties: {
+    blockClass: {
+      title: 'admin/editor.blockClass.title',
+      description: 'admin/editor.blockClass.description',
+      type: 'string',
+      isLayout: true,
+    }
+  }
 })
 
 export default SubmenuAccordion

--- a/react/SubmenuAccordion.tsx
+++ b/react/SubmenuAccordion.tsx
@@ -17,9 +17,9 @@ const SubmenuAccordion: StorefrontFunctionComponent<Props> = ({
   children,
   blockClass
 }) => {
-  const classes = generateBlockClass(styles.CustomSubmenuAccordion, blockClass)
+  const classes = generateBlockClass(styles.submenuAccordion, blockClass)
 
-  return(
+  return (
     <Collapsible open={isOpen}>
       <section
         className={classNames(classes, "w-100 flex pl4 flex")}

--- a/react/SubmenuAccordion.tsx
+++ b/react/SubmenuAccordion.tsx
@@ -44,14 +44,6 @@ const messages = defineMessages({
 SubmenuAccordion.getSchema = () => ({
   title: messages.submenuTitle.id,
   type: 'object',
-  properties: {
-    blockClass: {
-      title: 'admin/editor.blockClass.title',
-      description: 'admin/editor.blockClass.description',
-      type: 'string',
-      isLayout: true,
-    }
-  }
 })
 
 export default SubmenuAccordion

--- a/react/package.json
+++ b/react/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/ramda": "^0.26.5",
+    "@vtex/css-handles": "^1.0.0",
     "classnames": "^2.2.6",
     "graphql": "^14.1.1",
     "ramda": "^0.26.1",

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1092,6 +1092,11 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
+"@vtex/css-handles@^1.0.0":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@vtex/css-handles/-/css-handles-1.1.3.tgz#30bd1010f2907443188738f74dd11d3b6b4ac624"
+  integrity sha512-DkqnzMf5jW6lQ1L8wYb9fnXyh0FqZym8qEokGYjeLUqBLBAiVK8XbI4U0ezFswWTOJ3iHZUkUjqPt5WodxR29w==
+
 "@vtex/test-tools@^0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@vtex/test-tools/-/test-tools-0.1.4.tgz#c807fe429300a50c660250b2572b58b60573b76f"


### PR DESCRIPTION
#### What is the purpose of this pull request?
To increment on menu and their submenus a classes, to make more easy insert a different styles on anothers areas of website.

#### What problem is this solving?
Without this, we can't use menu on differents areas with different styles, mainly get subitens. Was very hard to make a layout without this option. 

#### How should this be manually tested?
https://giovanatexas--qdlab.myvtex.com/

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/26018620/59304691-231ef280-8c6f-11e9-9572-afe883e863b7.png)

![image](https://user-images.githubusercontent.com/26018620/59304593-ee12a000-8c6e-11e9-8cdd-e48d56f573c1.png)

![image](https://user-images.githubusercontent.com/26018620/59304642-0aaed800-8c6f-11e9-9d9a-998c1ba91a5b.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
