### PR TITLE
Allows image component to be placed within sub-menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Allowed `image` component on sub-menus. 
+
 ## [2.16.0] - 2019-06-14
 
 ### Added

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -23,7 +23,8 @@
       "info-card",
       "submenu-col",
       "flex-layout",
-      "notification"
+      "notification",
+      "image"
     ]
   },
   "submenu.accordion": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
To make it able to put an image inside a submenu

#### What problem is this solving?
Image component wasn't allowed previously within a submenu

#### How should this be manually tested?
Insert an image as child from a sub-menu

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/18701182/60451592-c924a380-9c02-11e9-9724-3c26aab34c30.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
