### PR TITLE
Fix/sub accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Allows accordion submenus to expand the height of their parents.
 
 ## [2.17.0] - 2019-07-11
 ### Added

--- a/react/SubmenuAccordion.tsx
+++ b/react/SubmenuAccordion.tsx
@@ -1,36 +1,34 @@
 import classNames from 'classnames'
 import React from 'react'
 import { defineMessages } from 'react-intl'
-import Collapsible from './components/Collapsible'
+import Collapsible, { CollapsibleContextConsumer } from './components/Collapsible'
 
 import { generateBlockClass } from '@vtex/css-handles'
 
 import styles from './SubmenuAccordion.css'
 
 interface Props {
-  isOpen: boolean,
+  isOpen: boolean
   blockClass?: string
 }
 
 const SubmenuAccordion: StorefrontFunctionComponent<Props> = ({
   isOpen,
   children,
-  blockClass
+  blockClass,
 }) => {
   const classes = generateBlockClass(styles.submenuAccordion, blockClass)
 
   return (
-    <Collapsible open={isOpen}>
-      <section
-        className={classNames(classes, "w-100 flex pl4 flex")}
-        style={{
-          WebkitOverflowScrolling: 'touch',
-          maxHeight: 400,
-          overflowY: 'scroll',
-        }}>
-        {children}
-      </section>
-    </Collapsible>
+    <CollapsibleContextConsumer>
+      {({ updateParentHeight }) => (
+        <Collapsible open={isOpen} updateParentHeight={updateParentHeight}>
+          <section className={classNames(classes, 'w-100 flex pl4 flex')}>
+            {children}
+          </section>
+        </Collapsible>
+      )}
+    </CollapsibleContextConsumer>
   )
 }
 

--- a/react/SubmenuAccordion.tsx
+++ b/react/SubmenuAccordion.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames'
 import React from 'react'
 import { defineMessages } from 'react-intl'
-import Collapsible, { CollapsibleContextConsumer } from './components/Collapsible'
+import Collapsible from './components/Collapsible'
 
 import { generateBlockClass } from '@vtex/css-handles'
 
@@ -20,15 +20,11 @@ const SubmenuAccordion: StorefrontFunctionComponent<Props> = ({
   const classes = generateBlockClass(styles.submenuAccordion, blockClass)
 
   return (
-    <CollapsibleContextConsumer>
-      {({ updateParentHeight }) => (
-        <Collapsible open={isOpen} updateParentHeight={updateParentHeight}>
-          <section className={classNames(classes, 'w-100 flex pl4 flex')}>
-            {children}
-          </section>
-        </Collapsible>
-      )}
-    </CollapsibleContextConsumer>
+    <Collapsible open={isOpen} >
+      <section className={classNames(classes, 'w-100 flex pl4 flex')}>
+        {children}
+      </section>
+    </Collapsible>
   )
 }
 

--- a/react/components/Collapsible.tsx
+++ b/react/components/Collapsible.tsx
@@ -1,20 +1,24 @@
-import React from 'react'
+import React, { FunctionComponent, Ref, RefForwardingComponent, PropsWithChildren } from 'react'
+
+const TRANSITION_DELAY = 200
 
 interface Props {
   open: boolean
-  transition: number
+  updateParentHeight?: (offset?: number) => void
 }
 
 interface State {
   height: number | string
 }
 
-class Collapsible extends React.Component<Props, State> { 
-  /*tslint:disable member-ordering */
-  public static defaultProps = {
-    transition: 200,
-  }
+interface CollapsibleContextValue {
+  updateParentHeight?: (offset?: number) => void
+}
 
+const CollapsibleContext = React.createContext<CollapsibleContextValue>({})
+
+class Collapsible extends React.Component<Props, State> {
+  /*tslint:disable member-ordering */
   private container = React.createRef<HTMLDivElement>()
 
   public state = {
@@ -31,46 +35,100 @@ class Collapsible extends React.Component<Props, State> {
 
   public componentDidUpdate(prevProps: Props) {
     if (!prevProps.open && this.props.open) {
-      const element = this.container.current
-      if (!element) {
-        return
+      if (typeof this.props.updateParentHeight === 'function') {
+        const childrenHeight = this.updateHeight()
+        this.props.updateParentHeight(childrenHeight)
+      } else {
+        this.updateHeight()
       }
-
-      element.style.height = 'auto'
-      const childrenHeight = element.offsetHeight
-
-      element.style.height = '0'
-
-      /** Forces layout in order to make the transition
-       * to the new height work.
-       */
-      this.forceLayout(element)
-
-      this.setState({
-        height: childrenHeight,
-      })
     } else if (prevProps.open && !this.props.open) {
-      this.setState({ height: 0 })
+      const childrenHeight = this.updateHeight()
+      if (typeof this.props.updateParentHeight === 'function') {
+        this.props.updateParentHeight(-childrenHeight)
+      }
+    }
+  }
+
+  public updateHeight = (offset?: number) => {
+    const element = this.container.current
+    if (!element) {
+      return 0
+    }
+
+    const initialHeight = element.offsetHeight
+
+    element.style.height = 'auto'
+    const childrenHeight = element.offsetHeight
+
+    element.style.height = `${initialHeight}px`
+
+    /** Forces layout in order to make the transition
+     * to the new height work.
+     */
+    this.forceLayout(element)
+
+    const targetHeight = Math.max(
+      0,
+      (this.props.open ? childrenHeight : 0) + (offset || 0)
+    )
+
+    this.setState({ height: targetHeight })
+
+    return childrenHeight
+  }
+
+  public updateHeightFromChildren = (offset?: number) => {
+    this.updateHeight(offset)
+  }
+
+  private handleUpdateParentHeight = (updateParentHeight: CollapsibleContextValue['updateParentHeight']) => (offset?: number) => {
+    this.updateHeightFromChildren(offset)
+    if (typeof updateParentHeight === 'function') {
+      updateParentHeight(offset)
     }
   }
 
   public render() {
-    const { children, transition } = this.props
+    const { children } = this.props
     const { height } = this.state
 
     return (
-      <div
-        className="overflow-hidden"
-        ref={this.container}
-        style={{
-          height,
-          transition: `height ${transition}ms ease-out`,
-        }}>
-          {children}
-      </div>
+      <CollapsibleContext.Consumer>
+        {({ updateParentHeight }) => (
+          <CollapsibleContext.Provider
+            value={{ updateParentHeight: this.handleUpdateParentHeight(updateParentHeight) }}
+          >
+            <CollapsibleContainer height={height} ref={this.container}>
+              {children}
+            </CollapsibleContainer>
+          </CollapsibleContext.Provider>
+        )}
+      </CollapsibleContext.Consumer>
     )
   }
 }
 
+type CollapsibleContainerProps = PropsWithChildren<{
+  height: number 
+}>
+
+const CollapsibleContainer = React.forwardRef(
+  (({ children, height }, ref) => (
+    <div
+      className="overflow-hidden"
+      ref={ref}
+      style={{
+        height,
+        transition: `height ${TRANSITION_DELAY}ms ease-out`,
+      }}
+    >
+      {children}
+    </div>
+  )) as RefForwardingComponent<HTMLDivElement, CollapsibleContainerProps>
+) 
+
 export default Collapsible
 
+const CollapsibleContextConsumer = CollapsibleContext.Consumer
+
+export { CollapsibleContextConsumer }

--- a/react/components/Collapsible.tsx
+++ b/react/components/Collapsible.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect, useContext, FunctionComponent, useMemo } from 'react'
 
-const TRANSITION_DELAY = 200
+const TRANSITION_DELAY = 250
 
 function isFunction(value: any): value is (...rest: any) => any {
   return typeof value === 'function'


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allows children of collapsible accordion menus to expand their parents.

Before:
![menu-before](https://user-images.githubusercontent.com/5691711/61295990-9a383100-a7af-11e9-897c-43c724b94c7e.gif)

After:
![menu-after](https://user-images.githubusercontent.com/5691711/61295996-9efce500-a7af-11e9-8e16-9b5d0e867ae5.gif)

https://lbebber--alssports.myvtex.com


#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
