### PR TITLE
Fix href IO message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Menu items href must be an IO message
+
 ## [2.17.1] - 2019-07-16
 ### Fixed
 - Allows accordion submenus to expand the height of their parents.

--- a/react/components/CustomItem.tsx
+++ b/react/components/CustomItem.tsx
@@ -9,7 +9,7 @@ const CustomItem: FunctionComponent<CustomItemProps & InjectedIntlProps> = props
   return (
     <StyledLink
       {...rest}
-      to={href}
+      to={formatIOMessage({ id: href, intl })}
       title={formatIOMessage({ id: tagTitle, intl })}
       {...(type === 'external' ? { target: '_blank', rel: 'noopener' } : {})}
       {...(noFollow ? { rel: 'nofollow noopener' } : {})}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Get the correct href for menu item.

#### What problem is this solving?
The href for menu items were not being translated properly, so the generated url was something like `https://adb-acessorios-para-patchwork.mygocommerce.com/store/menu-item.itemProps.href.7ziR3MKai6EeRkWLowgboH~g7KzNCKjvYMqppSvaDyoZk`. The href must be an IO Message for friendly href purposes. 

#### How should this be manually tested?
https://augusto--adb-acessorios-para-patchwork.mygocommerce.com/

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
