### PR TITLE
Fixed styledLink's href when it had a `?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- StyledLink's href when it had a question mark
+
 ## [2.18.0] - 2019-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.18.0] - 2019-07-23
 
 ### Added
+
 - MenuItems can have icon now by receiving the `iconProps` and `iconToTheRight` props
 
 ## [2.17.2] - 2019-07-16

--- a/react/components/StyledLink.tsx
+++ b/react/components/StyledLink.tsx
@@ -66,8 +66,6 @@ const StyledLink: FunctionComponent<StyledLinkProps> = props => {
     </div>
   )
 
-  const [path, query] = (to || '').split('?')
-
   return (
     <div
       className={classNames(styles.styledLinkContainer, 'mh6', {
@@ -79,9 +77,8 @@ const StyledLink: FunctionComponent<StyledLinkProps> = props => {
         <span className={linkClassNames}>{content}</span>
       ) : (
         <Link
-          to={path}
+          to={to}
           {...rest}
-          query={query}
           className={linkClassNames}
         >
           {content}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix [this](https://github.com/vtex-apps/store-discussion/issues/81)

#### How should this be manually tested?
[Workspace](https://iaronaraujo--storecomponents.myvtex.com)

Click on the `news` button in the footer and you should be redirected to Google

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
