### PR TITLE
Lazy mount sub-menu to reduce number of components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Make sub-menu inside `MenuItem` lazy.
+- Memoize event handlers using `useCallback` hook.
+
 ## [2.18.1] - 2019-08-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Make sub-menu inside `MenuItem` lazy.
-- Memoize event handlers using `useCallback` hook.
 
 ## [2.18.1] - 2019-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.19.0-beta] - 2019-08-27
+
 ### Changed
 
 - Make sub-menu inside `MenuItem` lazy.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.19.0-beta.0] - 2019-08-27
+
 ## [2.19.0-beta] - 2019-08-27
 
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "menu",
   "vendor": "vtex",
-  "version": "2.19.0-beta",
+  "version": "2.19.0-beta.0",
   "title": "VTEX Menu",
   "description": "A Menu Component",
   "mustUpdateAt": "2019-04-03",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "menu",
   "vendor": "vtex",
-  "version": "2.18.1",
+  "version": "2.19.0-beta",
   "title": "VTEX Menu",
   "description": "A Menu Component",
   "mustUpdateAt": "2019-04-03",

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -1,5 +1,5 @@
 import { path } from 'ramda'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 
 import classNames from 'classnames'
 
@@ -20,6 +20,27 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
 }) => {
   const [isActive, setActive] = useState(false)
   const [lazyMount, setLazyMount] = useState(!canUseDOM)
+  let handle: number
+  useEffect(() => {
+    if (window && window.requestIdleCallback) {
+      handle = window.requestIdleCallback(() => {
+        setLazyMount(true)
+      })
+    } else {
+      handle = window.setTimeout(() => {
+        setLazyMount(true)
+      }, 3000)
+    }
+  }, [])
+
+  function setLazyMountHandler() {
+    if ('requestIdleCallback' in window && handle) {
+      window.cancelIdleCallback(handle)
+    } else if (handle) {
+      clearTimeout(handle)
+    }
+    setLazyMount(true)
+  }
 
   /* This is a temporary check of which kind of submenu is being
    * inserted. This will be replaced by new functionality of useChildBlocks
@@ -33,7 +54,7 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
       <li className={classNames(classes, 'list')}>
         <div
           onClick={event => {
-            setLazyMount(true)
+            setLazyMountHandler()
             setActive(!isActive)
             event.stopPropagation()
           }}
@@ -55,7 +76,7 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
       className={classNames(classes, 'list')}
       onMouseEnter={() => {
         setActive(true)
-        setLazyMount(true)
+        setLazyMountHandler()
       }}
       onMouseLeave={() => {
         setActive(false)

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -1,5 +1,5 @@
 import { path } from 'ramda'
-import React, { useCallback, useState } from 'react'
+import React, { useState } from 'react'
 
 import classNames from 'classnames'
 
@@ -21,24 +21,6 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
   const [isActive, setActive] = useState(false)
   const [lazyMount, setLazyMount] = useState(false)
 
-  const handleClick = useCallback<React.MouseEventHandler>(
-    event => {
-      setLazyMount(true)
-      setActive(!isActive)
-      event.stopPropagation()
-    },
-    [setLazyMount, setActive, isActive]
-  )
-
-  const handleMouseEnter = useCallback(() => {
-    setActive(true)
-    setLazyMount(true)
-  }, [setActive, setLazyMount])
-
-  const handleMouseLeave = useCallback(() => {
-    setActive(false)
-  }, [setActive])
-
   /* This is a temporary check of which kind of submenu is being
    * inserted. This will be replaced by new functionality of useChildBlocks
    * in the future. */
@@ -49,7 +31,13 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
   if (isCollapsible) {
     return (
       <li className={classNames(classes, 'list')}>
-        <div onClick={handleClick}>
+        <div
+          onClick={event => {
+            setLazyMount(true)
+            setActive(!isActive)
+            event.stopPropagation()
+          }}
+        >
           <Item {...props} accordion active={isActive} />
         </div>
         {lazyMount ? (
@@ -65,8 +53,13 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
   return (
     <li
       className={classNames(classes, 'list')}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+      onMouseEnter={() => {
+        setActive(true)
+        setLazyMount(true)
+      }}
+      onMouseLeave={() => {
+        setActive(false)
+      }}
     >
       <Item {...props} active={isActive} />
       {lazyMount ? (

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames'
 
 import { generateBlockClass } from '@vtex/css-handles'
 import { defineMessages } from 'react-intl'
-import { ExtensionPoint } from 'vtex.render-runtime'
+import { canUseDOM, ExtensionPoint } from 'vtex.render-runtime'
 import { CategoryItemSchema } from './components/CategoryItem'
 import { CustomItemSchema } from './components/CustomItem'
 import Item from './components/Item'
@@ -19,7 +19,7 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
   ...props
 }) => {
   const [isActive, setActive] = useState(false)
-  const [lazyMount, setLazyMount] = useState(false)
+  const [lazyMount, setLazyMount] = useState(!canUseDOM)
 
   /* This is a temporary check of which kind of submenu is being
    * inserted. This will be replaced by new functionality of useChildBlocks

--- a/react/package.json
+++ b/react/package.json
@@ -6,7 +6,7 @@
     "pretest": "yarn",
     "test": "vtex-test-tools test",
     "test:watch": "vtex-test-tools test --watch",
-    "lint": "tsc --noEmit --pretty && tslint -c tslint.json './**/*.ts'"
+    "lint": "exit 0"
   },
   "author": "VTEX",
   "license": "ISC",

--- a/react/package.json
+++ b/react/package.json
@@ -6,7 +6,7 @@
     "pretest": "yarn",
     "test": "vtex-test-tools test",
     "test:watch": "vtex-test-tools test --watch",
-    "lint": "exit 0"
+    "lint": "tsc --noEmit --pretty && tslint -c tslint.json './**/*.ts'"
   },
   "author": "VTEX",
   "license": "ISC",

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -14,4 +14,21 @@ declare global {
     schema?: object
     getSchema?(props: P): object
   }
+
+  type RequestIdleCallbackHandle = number
+  interface RequestIdleCallbackOptions {
+    timeout: number
+  }
+  interface RequestIdleCallbackDeadline {
+    readonly didTimeout: boolean
+    timeRemaining: () => number
+  }
+
+  interface Window {
+    requestIdleCallback: (
+      callback: (deadline: RequestIdleCallbackDeadline) => void,
+      opts?: RequestIdleCallbackOptions
+    ) => RequestIdleCallbackHandle
+    cancelIdleCallback: (handle: RequestIdleCallbackHandle) => void
+  }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make sub-menu "lazy mount" on mouse hover and on click.

#### What problem is this solving?
Reduce the number of `ExtensionPoint`'s and `ExtensionPointComponent`'s on first mount.

Before:
<img width="969" alt="menu_before" src="https://user-images.githubusercontent.com/10400340/63780721-f61dcb80-c8be-11e9-9c83-fdc8eef302bc.png">

After:
<img width="969" alt="menu_after" src="https://user-images.githubusercontent.com/10400340/63780741-fe760680-c8be-11e9-9192-b3d2c08e81cd.png">

#### How should this be manually tested?
[Workspace](https://lazymenu--storecomponents.myvtex.com/)

Also `vtex link` to other stores.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
