### PR TITLE
Prevent submenu rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Prevent submenu from rendering when it's not active.
 
 ## [2.19.0] - 2019-10-30
 ### Changed

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -1,16 +1,16 @@
 import { path } from 'ramda'
-import React, { useState } from 'react'
+import React, { useReducer } from 'react'
 
 import classNames from 'classnames'
 
+import { generateBlockClass } from '@vtex/css-handles'
 import { defineMessages } from 'react-intl'
 import { ExtensionPoint } from 'vtex.render-runtime'
 import { CategoryItemSchema } from './components/CategoryItem'
-import { IconProps} from './components/StyledLink'
 import { CustomItemSchema } from './components/CustomItem'
 import Item from './components/Item'
+import { IconProps} from './components/StyledLink'
 import useSubmenuImplementation from './hooks/useSubmenuImplementation'
-import { generateBlockClass } from '@vtex/css-handles'
 
 import styles from './MenuItem.css'
 
@@ -57,8 +57,8 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
         {hasBeenActive && ( /* Collapsible menus need to still persist after being open,
                              * to make the closing transition work properly */
           <>
-        <ExtensionPoint id="submenu" isOpen={isActive} />
-        <ExtensionPoint id="unstable--submenu" isOpen={isActive} />
+            <ExtensionPoint id="submenu" isOpen={isActive} />
+            <ExtensionPoint id="unstable--submenu" isOpen={isActive} />
           </>
         )}
       </li>
@@ -73,8 +73,8 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
       <Item {...props} active={isActive} />
       {isActive && (
         <>
-      <ExtensionPoint id="submenu" isOpen={isActive} />
-      <ExtensionPoint id="unstable--submenu" isOpen={isActive} />
+          <ExtensionPoint id="submenu" isOpen={isActive} />
+          <ExtensionPoint id="unstable--submenu" isOpen={isActive} />
         </>
       )}
     </li>

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -18,7 +18,24 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
   blockClass,
   ...props
 }) => {
-  const [isActive, setActive] = useState(false)
+  const [{ isActive, hasBeenActive }, dispatch] = useReducer((state, action) => {
+    switch (action.type) {
+      case 'SHOW_SUBMENU':
+        return {
+          hasBeenActive: true,
+          isActive: true,
+        }
+      case 'HIDE_SUBMENU':
+        return {
+          ...state,
+          isActive: false,
+        }
+    }
+  }, { isActive: false, hasBeenActive: false })
+
+  const setActive = (value: boolean) => {
+    dispatch({ type: value ? 'SHOW_SUBMENU' : 'HIDE_SUBMENU' })
+  }
 
   /* This is a temporary check of which kind of submenu is being
    * inserted. This will be replaced by new functionality of useChildBlocks
@@ -37,8 +54,13 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
           }}>
           <Item {...props} accordion active={isActive} />
         </div>
+        {hasBeenActive && ( /* Collapsible menus need to still persist after being open,
+                             * to make the closing transition work properly */
+          <>
         <ExtensionPoint id="submenu" isOpen={isActive} />
         <ExtensionPoint id="unstable--submenu" isOpen={isActive} />
+          </>
+        )}
       </li>
     )
   }
@@ -49,8 +71,12 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
       onMouseEnter={() => setActive(true)}
       onMouseLeave={() => setActive(false)}>
       <Item {...props} active={isActive} />
+      {isActive && (
+        <>
       <ExtensionPoint id="submenu" isOpen={isActive} />
       <ExtensionPoint id="unstable--submenu" isOpen={isActive} />
+        </>
+      )}
     </li>
   )
 }

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -1,5 +1,5 @@
 import { path } from 'ramda'
-import React, { useReducer } from 'react'
+import React, { Reducer, useReducer } from 'react'
 
 import classNames from 'classnames'
 
@@ -14,24 +14,39 @@ import useSubmenuImplementation from './hooks/useSubmenuImplementation'
 
 import styles from './MenuItem.css'
 
+const submenuInitialState = {
+  hasBeenActive: false,
+  isActive: false,
+}
+
+type SubmenuState = typeof submenuInitialState
+
+type SubmenuAction = 
+  | {type: 'SHOW_SUBMENU'}
+  | {type: 'HIDE_SUBMENU'}
+
+const submenuReducer: Reducer<SubmenuState, SubmenuAction> =  (state, action) => {
+  switch (action.type) {
+    case 'SHOW_SUBMENU':
+      return {
+        hasBeenActive: true,
+        isActive: true,
+      }
+    case 'HIDE_SUBMENU':
+      return {
+        ...state,
+        isActive: false,
+      }
+    default:
+      return state
+  }
+}
+
 const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
   blockClass,
   ...props
 }) => {
-  const [{ isActive, hasBeenActive }, dispatch] = useReducer((state, action) => {
-    switch (action.type) {
-      case 'SHOW_SUBMENU':
-        return {
-          hasBeenActive: true,
-          isActive: true,
-        }
-      case 'HIDE_SUBMENU':
-        return {
-          ...state,
-          isActive: false,
-        }
-    }
-  }, { isActive: false, hasBeenActive: false })
+  const [{ isActive, hasBeenActive }, dispatch] = useReducer(submenuReducer, submenuInitialState)
 
   const setActive = (value: boolean) => {
     dispatch({ type: value ? 'SHOW_SUBMENU' : 'HIDE_SUBMENU' })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Prevents submenu from rendering when it's not active, to improve rendering performance.

Before:
<img width="231" alt="Screen Shot 2019-10-31 at 12 23 05" src="https://user-images.githubusercontent.com/5691711/67960595-496f0b80-fbd9-11e9-9093-71a6c12020d8.png">

After:
<img width="258" alt="Screen Shot 2019-10-31 at 12 22 21" src="https://user-images.githubusercontent.com/5691711/67960606-4ecc5600-fbd9-11e9-80f8-b06ec7e454a1.png">



#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

https://lbebber3--alssports.myvtex.com/

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
