### PR TITLE
Rename duplicate `category` query to `categoryWithChildren`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Duplicate query name `category`. 
 
 ## [2.19.2] - 2019-11-04
 ### Fixed

--- a/react/graphql/categoryWithChildren.graphql
+++ b/react/graphql/categoryWithChildren.graphql
@@ -1,4 +1,4 @@
-query category($id: Int) {
+query categoryWithChildren($id: Int) {
   category(id: $id) {
     cacheId
     id


### PR DESCRIPTION
#### What is the purpose of this pull request?

There were two GraphQL queries with the same name `category`.

#### What problem is this solving?

This should fix build.

#### How should this be manually tested?

[Workspace](https://minicart--storecomponents.myvtex.com/)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
