### PR TITLE
make href a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- href prop in menu-item should be of type string and not a translatable text.
 
 ## [2.20.2] - 2019-12-09
 ### Added

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -158,7 +158,7 @@
                     },
                     "href": {
                       "title": "admin/editor.menu.item.params.href.title",
-                      "$ref": "app:vtex.native-types#/definitions/text"
+                      "type": "string"
                     },
                     "noFollow": {
                       "title": "admin/editor.menu.item.params.noFollow.title",


### PR DESCRIPTION
#### What is the purpose of this pull request?
in menu-item the href was being translated when it shouldn't, the urls will not be translated when you change locale, only when you change binding and this will be handled somewhere else.

![image](https://user-images.githubusercontent.com/4925068/70555648-3ea38100-1b5e-11ea-8887-f6b4c8b8bd62.png)


#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

https://menu--storecomponents.myvtex.com/?cultureInfo=ja-jp

menu-items should not have translated href

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
