### PR TITLE
dont pass href to formatIOMessage to avoid translating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Another bug from translating urls in `menu-item`.
 
 ## [2.20.5] - 2019-12-11
+### Fixed
+- Docs typo
 
 ## [2.20.4] - 2019-12-10
 ### Fixed

--- a/react/components/CustomItem.tsx
+++ b/react/components/CustomItem.tsx
@@ -9,7 +9,7 @@ const CustomItem: FunctionComponent<CustomItemProps & InjectedIntlProps> = props
   return (
     <StyledLink
       {...rest}
-      to={formatIOMessage({ id: href, intl })}
+      to={href}
       title={formatIOMessage({ id: tagTitle, intl })}
       {...(type === 'external' ? { target: '_blank', rel: 'noopener' } : {})}
       {...(noFollow ? { rel: 'nofollow noopener' } : {})}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4925068/70622176-1e290480-1bfa-11ea-925f-75830a104a4d.png)

Em alguns casos ainda aparecia a url traduzida