### PR TITLE
Add submenuWrapper css handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `submenuWrapper` handle to submenu component.
 
 ## [2.21.0] - 2020-01-02
 ### Changed

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
 
-VTEX Menu is a store component responsible for displaying a bar containing links and drop-down sub-menus. 
+VTEX Menu is a store component responsible for displaying a bar containing links and drop-down sub-menus.
 
 ![menu-app](https://user-images.githubusercontent.com/52087100/68619014-5af1c680-04a9-11ea-9cdc-23468bd55c23.png)
 
@@ -19,7 +19,7 @@ VTEX Menu is a store component responsible for displaying a bar containing links
 ```
 2. Add the `vtex.menu@2.x:menu` block to the [store header](https://github.com/vtex-apps/store-header/blob/master/store/interfaces.json) template.
 
-3. To build the store's menu options, you need to configure the `menu-item` blocks. These can be declared in two different ways in `vtex.menu@2.x:menu`: as children or as props. The advantage of this latest `menu-item` configuration compared is that Site Editor can be used to edit the blocks. 
+3. To build the store's menu options, you need to configure the `menu-item` blocks. These can be declared in two different ways in `vtex.menu@2.x:menu`: as children or as props. The advantage of this latest `menu-item` configuration compared is that Site Editor can be used to edit the blocks.
 
 ### `menu-item` as children
 
@@ -126,7 +126,7 @@ You can define a submenu for a menu-item:
 
 
 <div class="alert alert-info">
-The Menu block has no prerequisite children. Therefore, any menu block implementation does not need to have any blocks declared within it to properly function. 
+The Menu block has no prerequisite children. Therefore, any menu block implementation does not need to have any blocks declared within it to properly function.
 </div>
 
 The available `menu-item` block props are as follows:
@@ -169,7 +169,7 @@ The available `menu-item` block props are as follows:
 
 #### Customization
 
-In order to apply CSS customizations on this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization). 
+In order to apply CSS customizations on this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
 
 | CSS Handle             |
 | -----------------------|
@@ -177,20 +177,21 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `linkLeft`             |
 | `linkMiddle`           |
 | `linkRight`            |
-| `submenuAccordion`     |
-| `submenu`              |
-| `menuItem`             |
 | `menuContainer`        |
-| `styledLink`           |
-| `styledLinkContainer`  |
-| `styledLinkIcon`       |
-| `menuLinkNav`          |
+| `menuContainerNav`     |
+| `menuItem`             |
+| `menuItemInnerDiv`     |
 | `menuLinkDivLeft`      |
 | `menuLinkDivMiddle`    |
 | `menuLinkDivRight`     |
+| `menuLinkNav`          |
 | `renderLink`           |
-| `menuContainerNav`     |
-| `menuItemInnerDiv`     |
+| `styledLink`           |
+| `styledLinkContainer`  |
+| `styledLinkIcon`       |
+| `submenu`              |
+| `submenuWrapper`       |
+| `submenuAccordion`     |
 | `submenuContainer`     |
 
 ## Contributors

--- a/react/Submenu.tsx
+++ b/react/Submenu.tsx
@@ -43,7 +43,7 @@ const Submenu: StorefrontFunctionComponent<SubmenuProps> = ({
   return (
     <div className={`${handles.submenuContainer} ${width === '100%' ? '' : 'relative'}`}>
       <div
-        className={classNames(handles.submenuWrapper,`absolute left-0 bg-base pt${parseTachyonsValue(paddingTop, 'paddingTop')} pb${parseTachyonsValue(paddingBottom, 'paddingBottom')} bw1 bb b--muted-3 z-2`,
+        className={classNames(handles.submenuWrapper, `absolute left-0 bg-base pt${parseTachyonsValue(paddingTop, 'paddingTop')} pb${parseTachyonsValue(paddingBottom, 'paddingBottom')} bw1 bb b--muted-3 z-2`,
           {
             dn: !isOpen,
             flex: isOpen,

--- a/react/Submenu.tsx
+++ b/react/Submenu.tsx
@@ -4,7 +4,7 @@ import { defineMessages } from 'react-intl'
 
 import { useCssHandles } from 'vtex.css-handles'
 
-const CSS_HANDLES = ['submenu', 'submenuContainer'] as const
+const CSS_HANDLES = ['submenu', 'submenuWrapper', 'submenuContainer'] as const
 
 const MAX_TACHYONS_SCALE = 11
 export type TachyonsScaleInput = string | number | undefined
@@ -43,7 +43,7 @@ const Submenu: StorefrontFunctionComponent<SubmenuProps> = ({
   return (
     <div className={`${handles.submenuContainer} ${width === '100%' ? '' : 'relative'}`}>
       <div
-        className={classNames(`absolute left-0 bg-base pt${parseTachyonsValue(paddingTop, 'paddingTop')} pb${parseTachyonsValue(paddingBottom, 'paddingBottom')} bw1 bb b--muted-3 z-2`,
+        className={classNames(handles.submenuWrapper,`absolute left-0 bg-base pt${parseTachyonsValue(paddingTop, 'paddingTop')} pb${parseTachyonsValue(paddingBottom, 'paddingBottom')} bw1 bb b--muted-3 z-2`,
           {
             dn: !isOpen,
             flex: isOpen,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add a `submenuWrapper` handle.

#### What problem is this solving?

Missing handle on one of submenu's elements.

#### How should this be manually tested?

Open https://chris--storecomponents.myvtex.com/ and check if the `submenuContainer` direct children have a `submenuWrapper` class.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12702016/72620990-2a059600-391f-11ea-91b7-13203e2a4e44.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
