### PR TITLE
Make `menu-item` render children blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for rendering child blocks inside a `menu-item`.
 
 ## [2.22.0] - 2020-01-17
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,11 +12,12 @@ VTEX Menu is a store component responsible for displaying a bar containing links
 
 1. Import the menu's app to your dependencies as `manifest.json`, for example:
 
-```
-  dependencies: {
+```json
+  "dependencies": {
     "vtex.menu": "2.x"
   }
 ```
+
 2. Add the `vtex.menu@2.x:menu` block to the [store header](https://github.com/vtex-apps/store-header/blob/master/store/interfaces.json) template.
 
 3. To build the store's menu options, you need to configure the `menu-item` blocks. These can be declared in two different ways in `vtex.menu@2.x:menu`: as children or as props. The advantage of this latest `menu-item` configuration compared is that Site Editor can be used to edit the blocks.
@@ -124,7 +125,6 @@ You can define a submenu for a menu-item:
 }
 ```
 
-
 <div class="alert alert-info">
 The Menu block has no prerequisite children. Therefore, any menu block implementation does not need to have any blocks declared within it to properly function.
 </div>
@@ -133,12 +133,13 @@ The available `menu-item` block props are as follows:
 
 | Prop name      | Type     | Description                                          | Default value |
 | -------------- | -------- | ---------------------------------------------------- | ------------- |
-| `type`         | `String` | Menu item type, either `category` or `custom`                                            | `caterogy`           |
+| `type`         | `String` | Menu item type, either `category` or `custom`                                            | `category`           |
 | `id`         | `String` | menu item ID                                           | N/A           |
 | `highlight`         | `boolean` | Whether the item has highlight                                            | N/A           |
 | `iconPosition`         | `String` | Icon position relative to the menu item text. Either to the `left` or `right`                                           | `left`          |
 | `iconProps`         | `IconProps` | Icon props                                           | N/A           |
 | `itemProps`         | `CategoryItem` or `CustomItem` | Item props                                           | N/A           |
+
 - For icons in the menu items:
 
 | Prop name      | Type     | Description                                          | Default value |

--- a/manifest.json
+++ b/manifest.json
@@ -18,10 +18,8 @@
   "dependencies": {
     "vtex.store-components": "3.x",
     "vtex.store-graphql": "2.x",
-    "vtex.flex-layout": "0.x",
     "vtex.native-types": "0.x",
     "vtex.store-icons": "0.x",
-    "vtex.rich-text": "0.x",
     "vtex.css-handles": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -8,7 +8,7 @@ import { ExtensionPoint } from 'vtex.render-runtime'
 import { CategoryItemSchema } from './components/CategoryItem'
 import { CustomItemSchema } from './components/CustomItem'
 import Item from './components/Item'
-import { IconProps} from './components/StyledLink'
+import { IconProps } from './components/StyledLink'
 import useSubmenuImplementation from './hooks/useSubmenuImplementation'
 
 import { useCssHandles } from 'vtex.css-handles'
@@ -23,11 +23,12 @@ const submenuInitialState = {
 
 type SubmenuState = typeof submenuInitialState
 
-type SubmenuAction = 
-  | {type: 'SHOW_SUBMENU'}
-  | {type: 'HIDE_SUBMENU'}
+type SubmenuAction = { type: 'SHOW_SUBMENU' } | { type: 'HIDE_SUBMENU' }
 
-const submenuReducer: Reducer<SubmenuState, SubmenuAction> =  (state, action) => {
+const submenuReducer: Reducer<SubmenuState, SubmenuAction> = (
+  state,
+  action
+) => {
   switch (action.type) {
     case 'SHOW_SUBMENU':
       return {
@@ -45,10 +46,14 @@ const submenuReducer: Reducer<SubmenuState, SubmenuAction> =  (state, action) =>
 }
 
 const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
+  children,
   ...props
 }) => {
   const { experimentalOptimizeRendering } = useContext(MenuContext)
-  const [{ isActive, hasBeenActive }, dispatch] = useReducer(submenuReducer, submenuInitialState)
+  const [{ isActive, hasBeenActive }, dispatch] = useReducer(
+    submenuReducer,
+    submenuInitialState
+  )
   const handles = useCssHandles(CSS_HANDLES)
 
   const setActive = (value: boolean) => {
@@ -64,18 +69,21 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
   if (isCollapsible) {
     return (
       <li className={classNames(handles.menuItem, 'list')}>
-        <div className={handles.menuItemInnerDiv}
+        <div
+          className={handles.menuItemInnerDiv}
           onClick={event => {
             setActive(!isActive)
             event.stopPropagation()
-          }}>
+          }}
+        >
           <Item {...props} accordion active={isActive} />
         </div>
-        {(hasBeenActive || !experimentalOptimizeRendering) && ( /* Collapsible menus need to still persist after being open,
-                             * to make the closing transition work properly */
-          <>
+        {(hasBeenActive || !experimentalOptimizeRendering) && (
+          /* Collapsible menus need to still persist after being open,
+           * to make the closing transition work properly */ <>
             <ExtensionPoint id="submenu" isOpen={isActive} />
             <ExtensionPoint id="unstable--submenu" isOpen={isActive} />
+            {children}
           </>
         )}
       </li>
@@ -86,12 +94,14 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
     <li
       className={classNames(handles.menuItem, 'list')}
       onMouseEnter={() => setActive(true)}
-      onMouseLeave={() => setActive(false)}>
+      onMouseLeave={() => setActive(false)}
+    >
       <Item {...props} active={isActive} />
       {(isActive || !experimentalOptimizeRendering) && (
         <>
           <ExtensionPoint id="submenu" isOpen={isActive} />
           <ExtensionPoint id="unstable--submenu" isOpen={isActive} />
+          {children}
         </>
       )}
     </li>
@@ -196,4 +206,3 @@ MenuItem.getSchema = props => {
 }
 
 export default MenuItem
-

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -5,14 +5,12 @@
   "menu": {
     "component": "Menu",
     "composition": "children",
-    "allowed": ["menu-item"],
     "content": {
       "$ref": "app:vtex.menu#/definitions/Menu"
     }
   },
   "menu-item": {
     "component": "MenuItem",
-    "allowed": ["submenu"],
     "composition": "children",
     "content": {
       "$ref": "app:vtex.menu#/definitions/MenuItem"
@@ -23,45 +21,19 @@
     "composition": "children",
     "content": {
       "$ref": "app:vtex.menu#/definitions/Submenu"
-    },
-    "allowed": [
-      "menu",
-      "info-card",
-      "submenu-col",
-      "flex-layout",
-      "notification",
-      "rich-text",
-      "image"
-    ]
+    }
   },
   "submenu.accordion": {
     "component": "SubmenuAccordion",
-    "composition": "children",
-    "allowed": [
-      "menu",
-      "info-card",
-      "flex-layout",
-      "notification",
-      "rich-text",
-      "image"
-    ]
+    "composition": "children"
   },
   "submenu-col": {
     "component": "Column",
-    "composition": "children",
-    "allowed": [
-      "menu",
-      "info-card",
-      "flex-layout",
-      "notification",
-      "rich-text",
-      "image"
-    ]
+    "composition": "children"
   },
   "unstable--menu": {
     "component": "Menu",
-    "composition": "children",
-    "allowed": ["unstable--menu-item", "menu-item"]
+    "composition": "children"
   },
   "unstable--menu-item": {
     "component": "MenuItem",
@@ -69,22 +41,15 @@
   },
   "unstable--submenu": {
     "component": "Submenu",
-    "composition": "children",
-    "allowed": [
-      "unstable--second-level-menu",
-      "unstable--menu",
-      "unstable--col"
-    ]
+    "composition": "children"
   },
   "unstable--col": {
     "component": "Column",
-    "composition": "children",
-    "allowed": ["unstable--second-level-menu", "unstable--menu"]
+    "composition": "children"
   },
   "unstable--second-level-menu": {
     "component": "Menu",
-    "composition": "children",
-    "allowed": ["unstable--second-level-menu-item"]
+    "composition": "children"
   },
   "unstable--second-level-menu-item": {
     "component": "MenuItem"

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -12,6 +12,7 @@
   "menu-item": {
     "component": "MenuItem",
     "composition": "children",
+    "allowed": ["submenu"],
     "content": {
       "$ref": "app:vtex.menu#/definitions/MenuItem"
     }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -5,18 +5,15 @@
   "menu": {
     "component": "Menu",
     "composition": "children",
-    "allowed": [
-      "menu-item"
-    ],
+    "allowed": ["menu-item"],
     "content": {
       "$ref": "app:vtex.menu#/definitions/Menu"
     }
   },
   "menu-item": {
     "component": "MenuItem",
-    "allowed": [
-      "submenu"
-    ],
+    "allowed": ["submenu"],
+    "composition": "children",
     "content": {
       "$ref": "app:vtex.menu#/definitions/MenuItem"
     }
@@ -64,16 +61,11 @@
   "unstable--menu": {
     "component": "Menu",
     "composition": "children",
-    "allowed": [
-      "unstable--menu-item",
-      "menu-item"
-    ]
+    "allowed": ["unstable--menu-item", "menu-item"]
   },
   "unstable--menu-item": {
     "component": "MenuItem",
-    "allowed": [
-      "unstable--submenu"
-    ]
+    "allowed": ["unstable--submenu"]
   },
   "unstable--submenu": {
     "component": "Submenu",
@@ -87,17 +79,12 @@
   "unstable--col": {
     "component": "Column",
     "composition": "children",
-    "allowed": [
-      "unstable--second-level-menu",
-      "unstable--menu"
-    ]
+    "allowed": ["unstable--second-level-menu", "unstable--menu"]
   },
   "unstable--second-level-menu": {
     "component": "Menu",
     "composition": "children",
-    "allowed": [
-      "unstable--second-level-menu-item"
-    ]
+    "allowed": ["unstable--second-level-menu-item"]
   },
   "unstable--second-level-menu-item": {
     "component": "MenuItem"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Update `menu-item` interface to `composition: children`, which enables blocks to be passed through `children`.

#### What problem is this solving?

Enables users to further customize their menus. Also, this should enable them to use the `drawer` block inside a `menu-item` to achieve something such as: 

![image (1)](https://user-images.githubusercontent.com/27777263/75058886-a1988900-54ba-11ea-8aa6-064849bac774.png)

#### How should this be manually tested?

Open the following workspace on mobile and see that there is a `drawer` inside a `menu-item`.

[Workspace](https://menuchildren--storecomponents.myvtex.com/apparel---accessories/)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
