### PR TITLE
Add CSS handle to menu item when submenu is open or closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Add CSS handles modifiers of open and close to menu item.
 ## [2.27.0] - 2020-11-05
 ### Changed
 - Close submenus whenever the URL changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -186,6 +186,8 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `menuContainer`           |
 | `menuContainerNav`        |
 | `menuItem`                |
+| `menuItem--isOpen`        |
+| `menuItem--isClosed`      |
 | `menuItemInnerDiv`        |
 | `menuLinkDivLeft`         |
 | `menuLinkDivMiddle`       |

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -10,7 +10,7 @@ import React, {
 import classNames from 'classnames'
 import { defineMessages } from 'react-intl'
 import { ExtensionPoint } from 'vtex.render-runtime'
-import { useCssHandles } from 'vtex.css-handles'
+import { useCssHandles, applyModifiers } from 'vtex.css-handles'
 
 import { CategoryItemSchema } from './components/CategoryItem'
 import { CustomItemSchema } from './components/CustomItem'
@@ -113,9 +113,15 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
 
   const handles = useCssHandles(CSS_HANDLES)
 
+  const itemClasses = classNames(
+    handles.menuItem,
+    'list',
+    applyModifiers(handles.menuItem, isActive ? 'isOpen' : 'isClosed')
+  )
+
   if (isCollapsible) {
     return (
-      <li className={classNames(handles.menuItem, 'list')}>
+      <li className={itemClasses}>
         {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
         <div
           className={handles.menuItemInnerDiv}
@@ -140,7 +146,7 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
 
   return (
     <li
-      className={classNames(handles.menuItem, 'list')}
+      className={itemClasses}
       onMouseEnter={() => {
         debouncedSetActive(true)
         setHovered(true)


### PR DESCRIPTION
#### What problem is this solving?

Allowing menu item customization when submenu is open or closed

#### How to test it?

[Workspace](https://menuitemcsshandles--tokstokio.myvtex.com/)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/34974565/100167520-0778cd80-2e9e-11eb-81d8-b24fca7ef9af.png)
