### PR TITLE
Feature/menu item css handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add CSS handles modifiers of open and close to menu item.
+
 ## [2.29.0] - 2021-03-08
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -190,6 +190,8 @@ In order to apply CSS customizations on this and other blocks, follow the instru
 | `menuContainer`            |
 | `menuItemInnerDiv`         |
 | `menuItem`                 |
+| `menuItem--isOpen`         |
+| `menuItem--isClosed`       |
 | `menuLinkDivLeft`          |
 | `menuLinkDivMiddle`        |
 | `menuLinkDivRight`         |

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -10,7 +10,11 @@ import React, {
 import classNames from 'classnames'
 import { defineMessages } from 'react-intl'
 import { ExtensionPoint } from 'vtex.render-runtime'
-import { useCssHandles, CssHandlesTypes } from 'vtex.css-handles'
+import {
+  useCssHandles,
+  CssHandlesTypes,
+  applyModifiers,
+} from 'vtex.css-handles'
 
 import { CategoryItemSchema } from './components/CategoryItem'
 import { CustomItemSchema } from './components/CustomItem'
@@ -125,9 +129,14 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
 
   const { handles } = useCssHandles(CSS_HANDLES, { classes: props.classes })
 
+  const itemClasses = classNames(
+    'list',
+    applyModifiers(handles.menuItem, isActive ? 'isOpen' : 'isClosed')
+  )
+
   if (isCollapsible) {
     return (
-      <li className={classNames(handles.menuItem, 'list')}>
+      <li className={itemClasses}>
         {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
         <div
           className={handles.menuItemInnerDiv}
@@ -152,7 +161,7 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
 
   return (
     <li
-      className={classNames(handles.menuItem, 'list')}
+      className={itemClasses}
       onMouseEnter={() => {
         debouncedSetActive(true)
         setHovered(true)


### PR DESCRIPTION
#### What problem is this solving?

Allowing menu item customization when submenu is open or closed

#### How to test it?

[Workspace](https://menuitemcsshandles--tokstokio.myvtex.com/)

#### Screenshots or example usage:

![image](https://user-images.githubusercontent.com/81425175/112673950-19ff1580-8e44-11eb-8e69-b54dfad5d0d2.png)

#### How does this PR make you feel? [:link:]()

![giphy](https://user-images.githubusercontent.com/81425175/112674433-b2959580-8e44-11eb-997d-c6392dac5487.gif)

