### PR TITLE
SVG icon from Site Editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Update schema to be able to change svg icon from Site Editor
 
 ## [2.32.0] - 2021-06-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-
 - Update schema to be able to change svg icon from Site Editor
 
 ## [2.32.0] - 2021-06-24

--- a/messages/context.json
+++ b/messages/context.json
@@ -35,6 +35,10 @@
   "admin/editor.menu.item.custom.title": "'custom' item type title",
   "admin/editor.menu.item.editorItemTitle.title": "editorItemTitle title",
   "admin/editor.menu.item.iconId.title": "iconId title",
+  
+  "admin/editor.menu.item.iconProps": "iconProps title",
+  "admin/editor.menu.item.iconProps.id.title": "iconId title",
+
   "admin/editor.menu.item.highlight.title": "highlight title",
   "admin/editor.menu.item.submenuWidth.title": "subMenuWidth title",
   "admin/editor.menu.item.params.title": "params Title",

--- a/messages/en.json
+++ b/messages/en.json
@@ -36,6 +36,10 @@
   "admin/editor.menu.item.iconId.title": "Icon ID",
   "admin/editor.menu.item.editorItemTitle.title": "Menu Item Name",
   "admin/editor.menu.item.editorItemTitle.description": "This will only be visible on Site Editor",
+  
+  "admin/editor.menu.item.iconProps": "Icon Props",
+  "admin/editor.menu.item.iconProps.id.title": "Icon ID",
+  
   "admin/editor.menu.item.highlight.title": "Highlight",
   "admin/editor.menu.item.submenuWidth.title": "Submenu Width",
   "admin/editor.menu.item.params.title": "Params",

--- a/react/components/StyledLink.tsx
+++ b/react/components/StyledLink.tsx
@@ -59,7 +59,7 @@ const StyledLink: FunctionComponent<StyledLinkProps> = props => {
   )
 
   const iconTestId = `icon-${iconPosition}`
-  const iconComponent = iconProps ? (
+  const iconComponent = iconProps?.id ? (
     <span className={`${handles.styledLinkIcon} mh2`} data-testid={iconTestId}>
       <Icon
         id={iconProps.id}

--- a/react/components/StyledLink.tsx
+++ b/react/components/StyledLink.tsx
@@ -62,7 +62,7 @@ const StyledLink: FunctionComponent<StyledLinkProps> = props => {
   const iconComponent = iconProps?.id ? (
     <span className={`${handles.styledLinkIcon} mh2`} data-testid={iconTestId}>
       <Icon
-        id={iconProps.id}
+        id={iconProps.id ? iconProps.id : iconId}
         isActive={iconProps.isActive}
         size={iconProps.size}
         viewBox={iconProps.viewBox}

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -140,6 +140,16 @@
                 "itemProps": {
                   "type": "object",
                   "properties": {
+                    "iconProps": {
+                      "title": "Icon Props",
+                      "properties": {
+                        "id": {
+                          "title": "Icon Props: ID",
+                          "type": "string",
+                          "default": null
+                        }
+                      }
+                    },
                     "type": {
                       "title": "admin/editor.menu.item.params.type.title",
                       "type": "string",

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -141,10 +141,10 @@
                   "type": "object",
                   "properties": {
                     "iconProps": {
-                      "title": "Icon Props",
+                      "title": "admin/editor.menu.item.iconProps",
                       "properties": {
                         "id": {
-                          "title": "Icon Props: ID",
+                          "title": "admin/editor.menu.item.iconProps.id.title",
                           "type": "string",
                           "default": null
                         }
@@ -210,11 +210,6 @@
           "widget": {
             "ui:widget": "radio"
           }
-        },
-        "iconId": {
-          "title": "admin/editor.menu.item.iconId.title",
-          "type": "string",
-          "nullable": true
         }
       }
     },


### PR DESCRIPTION
#### What problem is this solving?
Be able to edit the SVG icon from Site Editor. Currently, to change an icon it is necessary to do it from the theme app.

This is useful for not repeating different `menu` or `menu-item` blocks in the .jsonc files just to change the icon, instead, it is possible to have only one general block and do all customization from Site Editor. This will also make site maintenance easier.

#### How to test it?
[Workspace / Site Editor](https://featuremenuiconsfromsiteeditor--martimxlite.myvtex.com)
1. Use Mobile view
2. Click on hamburguer menu icon
3. Select any menu item (menu-item or menu)
4. Edit the menu item
5. Change the id of svg icon (Icon Props: ID) by `svgIcon-house`

#### Screenshots or example usage:
![Screenshot_20210808-171647](https://user-images.githubusercontent.com/23274114/128647561-62860db8-b5f4-46f0-b28e-4468060772fc.jpg)
![Screenshot_20210808-171705](https://user-images.githubusercontent.com/23274114/128647393-7c13d4c0-92b1-4b65-8ce5-bf718c1468ce.jpg)

#### How does this PR make you feel? [:link:](http://giphy.com/)
![](https://media.giphy.com/media/D7z8JfNANqahW/giphy.gif)
