### PR TITLE
Add back the categoryId to site editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add categoryId back - it was mistakenly removed in the previous deploy
 
 ## [2.34.1] - 2021-10-18
 ### Fixed

--- a/store/contentSchemas.json
+++ b/store/contentSchemas.json
@@ -118,7 +118,16 @@
                   "enum": [
                     "category"
                   ]
-                }                
+                },
+                "itemProps": {
+                  "type": "object",
+                  "properties": {
+                    "categoryId": {
+                      "title": "admin/editor.menu.item.params.categoryId.title",
+                      "type": "string"
+                    }
+                  } 
+                }             
               }
             },
             {


### PR DESCRIPTION
#### What problem is this solving?

As the title says. It shouldn't have been removed in this [PR](https://github.com/vtex-apps/menu/pull/149).

#### How to test it?

Check if the category Id field appears in the site editor of this [workspace](https://laricia--vasoecor.myvtex.com/admin/cms/site-editor).

#### Screenshots or example usage:

Before - without the field:
<img width="1498" alt="Screen Shot 2021-12-10 at 12 56 12" src="https://user-images.githubusercontent.com/19983991/145602992-7bb2e1e9-c84b-4907-a2d3-6e9052dad6c7.png">

After - with the field:
<img width="1498" alt="Screen Shot 2021-12-10 at 12 59 58" src="https://user-images.githubusercontent.com/19983991/145603652-7b991534-7a3c-4f6e-afe2-a4502a3dd107.png">

#### Describe alternatives you've considered, if any.

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/RkzZrtq0y4DlrvHF3T/giphy.gif)
