### PR TITLE
fix: deactivate item when is not open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Deactivate item when is not open or hovered
+
 ## [2.35.0] - 2023-04-03
 
 ### Added

--- a/react/MenuItem.tsx
+++ b/react/MenuItem.tsx
@@ -136,10 +136,14 @@ const MenuItem: StorefrontFunctionComponent<MenuItemSchema> = ({
       }
 
       // if a menu is still active but is not hovered for at least 400ms, close it
-      if (isActive && !isHovered && onMountBehaviorFlag === 'closed') {
+      if (isActive && !isHovered && onMountBehaviorFlag !== 'open') {
         closeTimeout.current = window.setTimeout(() => {
           setActive(false)
         }, 400)
+      }
+
+      return () => {
+        closeTimeout.current && clearTimeout(closeTimeout.current)
       }
     },
     [isActive, isCollapsible, isHovered, setActive, onMountBehaviorFlag]


### PR DESCRIPTION
#### What problem is this solving?

When we have a item hovered (active) and move the mouse to another element very fast, sometimes the `isActive` state does not change to false, because in evaluation `onMountBehaviorFlag==="close"` `onMountBehaviorFlag` sometimes comes to undefined

#### How to test it?

[Workspace](https://ycl--poccarrefourarg.myvtex.com/)

#### Screenshots or example usage:
before:

https://user-images.githubusercontent.com/40153830/226982476-ef39c350-918c-49e5-b204-a7e3ccb902d1.mp4

---
after:

https://user-images.githubusercontent.com/40153830/226982492-577a66b1-d4c8-4458-a88a-1e1beae6e135.mp4

